### PR TITLE
Refactor integrations

### DIFF
--- a/src/Tec/Integrations/Integration_Handler.php
+++ b/src/Tec/Integrations/Integration_Handler.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tribe\Extensions\Membersonlytickets\Integrations;
+
+/**
+ * Class Integration_Handler
+ *
+ * @since   1.1.0
+ *
+ * @package Tribe\Extensions\Membersonlytickets\Integrations
+ */
+class Integration_Handler extends \tad_DI52_ServiceProvider {
+
+	/**
+	 * Which classes we will load for order statuses by default.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @var string[]
+	 */
+	protected $default_integrations = [
+		Paid_Memberships_Pro::class,
+		Restrict_Content_Pro::class,
+		WooCommerce_Memberships::class,
+	];
+
+	protected $integrations = [];
+
+	/**
+	 * Sets up all the Status instances for the Classes registered in $default_statuses.
+	 *
+	 * @since 1.1.0
+	 */
+	public function register() {
+		foreach ( $this->default_integrations as $integration_class ) {
+			// Spawn the new instance.
+			$integration = new $integration_class;
+
+			// Register as a singleton for internal ease of use.
+			$this->container->singleton( $integration_class, $integration );
+
+			// Collect this particular status instance in this class.
+			$this->register_integration( $integration );
+		}
+
+		$this->container->singleton( static::class, $this );
+	}
+
+	/**
+	 * Register a given status into the Handler.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param Integration_Interface $integration Which status we are registering.
+	 */
+	public function register_integration( Integration_Interface $integration ) {
+		$this->integrations[] = $integration;
+	}
+
+	/**
+	 * Gets the statuses registered.
+	 *
+	 * @since 5.1.9
+	 *
+	 * @return Integration_Interface[]
+	 */
+	public function get_all() {
+		return $this->integrations;
+	}
+
+	/**
+	 * Fetches the first status registered with a given slug.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $id
+	 *
+	 * @return Integration_Interface|null
+	 */
+	public function get_by_id( $id ) {
+		foreach ( $this->get_all() as $integration ) {
+			if ( $integration::get_id() === $id ) {
+				return $integration;
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/src/Tec/Integrations/Integration_Handler.php
+++ b/src/Tec/Integrations/Integration_Handler.php
@@ -33,8 +33,9 @@ class Integration_Handler extends \tad_DI52_ServiceProvider {
 	 */
 	public function register() {
 		foreach ( $this->default_integrations as $integration_class ) {
+
 			// Spawn the new instance.
-			$integration = new $integration_class;
+			$integration = new $integration_class( $this->container );
 
 			// Register as a singleton for internal ease of use.
 			$this->container->singleton( $integration_class, $integration );

--- a/src/Tec/Integrations/Integration_Handler.php
+++ b/src/Tec/Integrations/Integration_Handler.php
@@ -5,16 +5,15 @@ namespace Tribe\Extensions\Membersonlytickets\Integrations;
 /**
  * Class Integration_Handler
  *
- * @since   1.1.0
+ * @since   1.0.0
  *
  * @package Tribe\Extensions\Membersonlytickets\Integrations
  */
 class Integration_Handler extends \tad_DI52_ServiceProvider {
-
 	/**
 	 * Which classes we will load for order statuses by default.
 	 *
-	 * @since 1.1.0
+	 * @since 1.0.0
 	 *
 	 * @var string[]
 	 */
@@ -24,12 +23,21 @@ class Integration_Handler extends \tad_DI52_ServiceProvider {
 		WooCommerce_Memberships::class,
 	];
 
+	/**
+	 * Stores integration instances.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array
+	 */
 	protected $integrations = [];
 
 	/**
 	 * Sets up all the Status instances for the Classes registered in $default_statuses.
 	 *
-	 * @since 1.1.0
+	 * @since 1.0.0
+	 *
+	 * @return void
 	 */
 	public function register() {
 		foreach ( $this->default_integrations as $integration_class ) {
@@ -40,6 +48,9 @@ class Integration_Handler extends \tad_DI52_ServiceProvider {
 			// Register as a singleton for internal ease of use.
 			$this->container->singleton( $integration_class, $integration );
 
+			// Register the service provider.
+			$this->container->register( $integration );
+
 			// Collect this particular status instance in this class.
 			$this->register_integration( $integration );
 		}
@@ -48,20 +59,22 @@ class Integration_Handler extends \tad_DI52_ServiceProvider {
 	}
 
 	/**
-	 * Register a given status into the Handler.
+	 * Register an integration.
 	 *
-	 * @since 1.1.0
+	 * @since 1.0.0
 	 *
 	 * @param Integration_Interface $integration Which status we are registering.
+	 *
+	 * @return void
 	 */
 	public function register_integration( Integration_Interface $integration ) {
 		$this->integrations[] = $integration;
 	}
 
 	/**
-	 * Gets the statuses registered.
+	 * Gets the registered integrations.
 	 *
-	 * @since 5.1.9
+	 * @since 1.0.0
 	 *
 	 * @return Integration_Interface[]
 	 */
@@ -72,7 +85,7 @@ class Integration_Handler extends \tad_DI52_ServiceProvider {
 	/**
 	 * Fetches the first status registered with a given slug.
 	 *
-	 * @since 1.1.0
+	 * @since 1.0.0
 	 *
 	 * @param string $id
 	 *
@@ -87,5 +100,4 @@ class Integration_Handler extends \tad_DI52_ServiceProvider {
 
 		return null;
 	}
-
 }

--- a/src/Tec/Integrations/Integration_Interface.php
+++ b/src/Tec/Integrations/Integration_Interface.php
@@ -5,51 +5,41 @@ namespace Tribe\Extensions\Membersonlytickets\Integrations;
 /**
  * Class Integration_Interface
  *
- * @since   TBD
+ * @since   1.0.0
  *
  * @package Tribe\Extensions\Membersonlytickets\Integrations
  */
 interface Integration_Interface {
 	/**
-	 *
-	 *
-	 * @since 1.1.0
+	 * @since 1.0.0
 	 *
 	 * @return boolean
 	 */
 	public function is_active();
 
 	/**
-	 *
-	 *
-	 * @since 1.1.0
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
 	public function add_actions();
 
 	/**
-	 *
-	 *
-	 * @since 1.1.0
+	 * @since 1.0.0
 	 *
 	 * @return void
 	 */
 	public function add_filters();
 
 	/**
-	 *
-	 *
-	 * @since 1.1.0
+	 * @since 1.0.0
 	 *
 	 * @return string
 	 */
 	public static function get_id();
 
 	/**
-	 *
-	 *
-	 * @since 1.1.0
+	 * @since 1.0.0
 	 *
 	 * @param int|string $product_id
 	 *
@@ -58,9 +48,7 @@ interface Integration_Interface {
 	public function can_view( $product_id );
 
 	/**
-	 *
-	 *
-	 * @since 1.1.0
+	 * @since 1.0.0
 	 *
 	 * @param int|string $product_id
 	 *

--- a/src/Tec/Integrations/Integration_Interface.php
+++ b/src/Tec/Integrations/Integration_Interface.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tribe\Extensions\Membersonlytickets\Integrations;
+
+/**
+ * Class Integration_Interface
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Extensions\Membersonlytickets\Integrations
+ */
+interface Integration_Interface {
+	/**
+	 *
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return boolean
+	 */
+	public function is_active();
+
+	/**
+	 *
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return void
+	 */
+	public function add_actions();
+
+	/**
+	 *
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return void
+	 */
+	public function add_filters();
+
+	/**
+	 *
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string
+	 */
+	public static function get_id();
+
+	/**
+	 *
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int|string $product_id
+	 *
+	 * @return boolean
+	 */
+	public function can_view( $product_id );
+
+	/**
+	 *
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int|string $product_id
+	 *
+	 * @return boolean
+	 */
+	public function can_purchase( $product_id );
+}

--- a/src/Tec/Integrations/Paid_Memberships_Pro.php
+++ b/src/Tec/Integrations/Paid_Memberships_Pro.php
@@ -32,8 +32,6 @@ class Paid_Memberships_Pro extends \tad_DI52_ServiceProvider implements Integrat
 	 * @return void
 	 */
 	public function register() {
-		$this->container->singleton( static::class, $this );
-
 		if ( ! $this->is_active() ) {
 			return;
 		}

--- a/src/Tec/Integrations/Paid_Memberships_Pro.php
+++ b/src/Tec/Integrations/Paid_Memberships_Pro.php
@@ -1,43 +1,39 @@
 <?php
-/**
- * Handles membership checks when using Paid Memberships Pro.
- *
- * @since   1.0.0
- * @package Tribe\Extensions\Membersonlytickets\Integrations
- */
 
 namespace Tribe\Extensions\Membersonlytickets\Integrations;
 
 /**
  * Class Paid_Memberships_Pro.
+ *
+ * Handles membership checks when using Paid Memberships Pro.
+ *
+ * @since   1.0.0
+ *
+ * @package Tribe\Extensions\Membersonlytickets\Integrations
  */
 class Paid_Memberships_Pro extends \tad_DI52_ServiceProvider implements Integration_Interface {
 
-	use Common;
+	use Integration_Traits;
 
+	/**
+	 * @inheritDoc
+	 */
 	public static function get_id() {
-		return 'restrict_content_pro';
-	}
-
-	public function is_active() {
-		// Get active plugins
-		$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
-		return in_array( 'paid-memberships-pro/paid-memberships-pro.php', $active_plugins, true );
+		return 'paid_memberships_pro';
 	}
 
 	/**
-	 * Binds and sets up implementations.
-	 *
-	 * @since 1.0.0
-	 * @return void
+	 * @inheritDoc
 	 */
-	public function register() {
-		if ( ! $this->is_active() ) {
-			return;
-		}
+	public function is_active() {
+		return defined( 'PMPRO_VERSION' );
+	}
 
-		$this->add_filters();
-		$this->add_actions();
+	/**
+	 * @inheritDoc
+	 */
+	public function add_actions() {
+		// TODO: Implement add_actions() method.
 	}
 
 	/**
@@ -48,13 +44,6 @@ class Paid_Memberships_Pro extends \tad_DI52_ServiceProvider implements Integrat
 		add_filter( 'tribe_template_html:tickets/v2/tickets/item/quantity', [ $this, 'ticket_quantity_template' ], 100, 4 );
 		add_filter( 'tribe_get_event_meta', [ $this, 'filter_cost' ], 100, 4 );
 		add_filter( 'extension.members_only_tickets.settings', [ $this, 'settings' ] );
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function add_actions() {
-		// TODO: Implement add_actions() method.
 	}
 
 	/**
@@ -74,7 +63,7 @@ class Paid_Memberships_Pro extends \tad_DI52_ServiceProvider implements Integrat
 	 * @inheritDoc
 	 */
 	public function can_purchase( $product_id ) {
-		// If this isn't a "members only" ticket, don't interfere.
+		// If not a "members only" ticket, don't interfere.
 		if ( ! $this->is_member_ticket( $product_id ) ) {
 			return true;
 		}
@@ -112,10 +101,14 @@ class Paid_Memberships_Pro extends \tad_DI52_ServiceProvider implements Integrat
 	 * @return array
 	 */
 	public function settings( $settings ) {
-		$settings[ $this->ID ] = [
+		$settings[ $this->get_id() ] = [
 			'members_settings_intro'   => [
 				'type' => 'html',
-				'html' => $this->get_settings_intro()
+				'html' => sprintf(
+					'<h3>%s</h3><p>%s</p>',
+					esc_html__( 'Membership', 'et-members-only-tickets' ),
+					esc_html__( 'Limit access to tickets by membership level with Paid Memberships Pro.', 'et-members-only-tickets' )
+				)
 			],
 			'product_category' => [
 				'type'            => 'text',
@@ -138,20 +131,5 @@ class Paid_Memberships_Pro extends \tad_DI52_ServiceProvider implements Integrat
 		];
 
 		return $settings;
-	}
-
-	/**
-	 * Create settings intro markup.
-	 *
-	 * @since 1.0.0
-	 * @return string
-	 */
-	protected function get_settings_intro() {
-		$result = '<h3>' . esc_html_x( 'Membership', 'Settings header', 'et-members-only-tickets' ) . '</h3>';
-		$result .= '<p>';
-		$result .= esc_html_x( 'Limit access to tickets by membership level with Paid Memberships Pro.', 'Setting section description', 'et-members-only-tickets' );
-		$result .= '</p>';
-
-		return $result;
 	}
 }

--- a/src/Tec/Integrations/Restrict_Content_Pro.php
+++ b/src/Tec/Integrations/Restrict_Content_Pro.php
@@ -32,8 +32,6 @@ class Restrict_Content_Pro extends \tad_DI52_ServiceProvider implements Integrat
 	 * @return void
 	 */
 	public function register() {
-		$this->container->singleton( static::class, $this );
-
 		if ( ! $this->is_active() ) {
 			return;
 		}

--- a/src/Tec/Integrations/Restrict_Content_Pro.php
+++ b/src/Tec/Integrations/Restrict_Content_Pro.php
@@ -11,17 +11,19 @@ namespace Tribe\Extensions\Membersonlytickets\Integrations;
 /**
  * Class Restrict_Content_Pro.
  */
-class Restrict_Content_Pro extends \tad_DI52_ServiceProvider {
+class Restrict_Content_Pro extends \tad_DI52_ServiceProvider implements Integration_Interface {
 
 	use Common;
 
-	/**
-	 * The integration slug.
-	 *
-	 * @since 1.0.0
-	 * @var string
-	 */
-	protected $ID = 'restrict_content_pro';
+	public static function get_id() {
+		return 'restrict_content_pro';
+	}
+
+	public function is_active() {
+		// Get active plugins
+		$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
+		return in_array( 'restrict-content-pro/restrict-content-pro.php', $active_plugins, true );
+	}
 
 	/**
 	 * Binds and sets up implementations.
@@ -30,41 +32,41 @@ class Restrict_Content_Pro extends \tad_DI52_ServiceProvider {
 	 * @return void
 	 */
 	public function register() {
-		$this->container->singleton( "extension.members_only_tickets.{ $this->ID }", $this );
-		$this->actions();
+		$this->container->singleton( static::class, $this );
+
+		if ( ! $this->is_active() ) {
+			return;
+		}
+		$this->add_filters();
+		$this->add_actions();
 	}
 
 	/**
-	 * Adds the actions and filters required by the integration.
-	 *
-	 * @since 1.0.0
-	 * @return void
+	 * @inheritDoc
 	 */
-	protected function actions() {
+	public function add_actions() {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function add_filters() {
 		add_filter( 'tribe_template_context', [ $this, 'remove_tickets_from_context' ], 100, 4 );
 		add_filter( 'tribe_template_html:tickets/v2/tickets/item/quantity', [ $this, 'ticket_quantity_template' ], 100, 4 );
 		add_filter( 'tribe_get_event_meta', [ $this, 'filter_cost' ], 100, 4 );
 	}
 
 	/**
-	 * Check if user can view tickets.
-	 *
-	 * @since 1.0.0
-	 * @param int $product_id
-	 * @return bool
+	 * @inheritDoc
 	 */
-	protected function can_view( $product_id ) {
+	public function can_view( $product_id ) {
 		return rcp_user_can_view_woocommerce_product( get_current_user_id(), $product_id );
 	}
 
 	/**
-	 * Check if user can purchase tickets.
-	 *
-	 * @since 1.0.0
-	 * @param int $product_id
-	 * @return bool
+	 * @inheritDoc
 	 */
-	protected function can_purchase( $product_id ) {
+	public function can_purchase( $product_id ) {
 		return rcp_user_can_purchase_woocommerce_product( get_current_user_id(), $product_id );
 	}
 }

--- a/src/Tec/Integrations/Restrict_Content_Pro.php
+++ b/src/Tec/Integrations/Restrict_Content_Pro.php
@@ -1,48 +1,39 @@
 <?php
-/**
- * Handles membership checks when using Restrict Content Pro.
- *
- * @since   1.0.0
- * @package Tribe\Extensions\Membersonlytickets\Integrations
- */
 
 namespace Tribe\Extensions\Membersonlytickets\Integrations;
 
 /**
  * Class Restrict_Content_Pro.
+ *
+ * Handles membership checks when using Restrict Content Pro.
+ *
+ * @since   1.0.0
+ *
+ * @package Tribe\Extensions\Membersonlytickets\Integrations
  */
 class Restrict_Content_Pro extends \tad_DI52_ServiceProvider implements Integration_Interface {
 
-	use Common;
+	use Integration_Traits;
 
+	/**
+	 * @inheritDoc
+	 */
 	public static function get_id() {
 		return 'restrict_content_pro';
 	}
 
-	public function is_active() {
-		// Get active plugins
-		$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
-		return in_array( 'restrict-content-pro/restrict-content-pro.php', $active_plugins, true );
-	}
-
 	/**
-	 * Binds and sets up implementations.
-	 *
-	 * @since 1.0.0
-	 * @return void
+	 * @inheritDoc
 	 */
-	public function register() {
-		if ( ! $this->is_active() ) {
-			return;
-		}
-		$this->add_filters();
-		$this->add_actions();
+	public function is_active() {
+		return class_exists( 'Restrict_Content_Pro' );
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	public function add_actions() {
+		// TODO: Implement add_actions() method.
 	}
 
 	/**

--- a/src/Tec/Integrations/WooCommerce_Memberships.php
+++ b/src/Tec/Integrations/WooCommerce_Memberships.php
@@ -1,19 +1,19 @@
 <?php
-/**
- * Handles membership checks when using WooCommerce Memberships.
- *
- * @since   1.0.0
- * @package Tribe\Extensions\Membersonlytickets\Integrations
- */
 
 namespace Tribe\Extensions\Membersonlytickets\Integrations;
 
 /**
  * Class WooCommerce_Memberships.
+ *
+ * Handles membership checks when using WooCommerce Memberships.
+ *
+ * @since   1.0.0
+ *
+ * @package Tribe\Extensions\Membersonlytickets\Integrations
  */
 class WooCommerce_Memberships extends \tad_DI52_ServiceProvider implements Integration_Interface {
 
-	use Common;
+	use Integration_Traits;
 
 	/**
 	 * @inheritDoc
@@ -26,22 +26,7 @@ class WooCommerce_Memberships extends \tad_DI52_ServiceProvider implements Integ
 	 * @inheritDoc
 	 */
 	public function is_active() {
-		// Get active plugins
-		$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
-
-		return in_array( 'woocommerce-memberships/woocommerce-memberships.php', $active_plugins, true );
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public function register() {
-		if ( ! $this->is_active() ) {
-			return;
-		}
-
-		$this->add_filters();
-		$this->add_actions();
+		return class_exists( 'WC_Memberships_Loader' );
 	}
 
 	/**

--- a/src/Tec/Integrations/WooCommerce_Memberships.php
+++ b/src/Tec/Integrations/WooCommerce_Memberships.php
@@ -36,8 +36,6 @@ class WooCommerce_Memberships extends \tad_DI52_ServiceProvider implements Integ
 	 * @inheritDoc
 	 */
 	public function register() {
-		$this->container->singleton( static::class, $this );
-
 		if ( ! $this->is_active() ) {
 			return;
 		}

--- a/src/Tec/Integrations/WooCommerce_Memberships.php
+++ b/src/Tec/Integrations/WooCommerce_Memberships.php
@@ -11,49 +11,61 @@ namespace Tribe\Extensions\Membersonlytickets\Integrations;
 /**
  * Class WooCommerce_Memberships.
  */
-class WooCommerce_Memberships extends \tad_DI52_ServiceProvider {
+class WooCommerce_Memberships extends \tad_DI52_ServiceProvider implements Integration_Interface {
 
 	use Common;
 
 	/**
-	 * The integration slug.
-	 *
-	 * @since 1.0.0
-	 * @var string
+	 * @inheritDoc
 	 */
-	protected $ID = 'woocommerce_memberships';
-
-	/**
-	 * Binds and sets up implementations.
-	 *
-	 * @since 1.0.0
-	 * @return void
-	 */
-	public function register() {
-		$this->container->singleton( "extension.members_only_tickets.{$this->ID}", $this );
-		$this->actions();
+	public static function get_id() {
+		return 'woocommerce_memberships';
 	}
 
 	/**
-	 * Adds the actions and filters required by the integration.
-	 *
-	 * @since 1.0.0
-	 * @return void
+	 * @inheritDoc
 	 */
-	protected function actions() {
+	public function is_active() {
+		// Get active plugins
+		$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
+
+		return in_array( 'woocommerce-memberships/woocommerce-memberships.php', $active_plugins, true );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function register() {
+		$this->container->singleton( static::class, $this );
+
+		if ( ! $this->is_active() ) {
+			return;
+		}
+
+		$this->add_filters();
+		$this->add_actions();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function add_actions() {
+		// TODO: Implement add_actions() method.
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function add_filters() {
 		add_filter( 'tribe_template_context', [ $this, 'remove_tickets_from_context' ], 100, 4 );
 		add_filter( 'tribe_template_html:tickets/v2/tickets/item/quantity', [ $this, 'ticket_quantity_template' ], 100, 4 );
 		add_filter( 'tribe_get_event_meta', [ $this, 'filter_cost' ], 100, 4 );
 	}
 
 	/**
-	 * Check if user can view a ticket.
-	 *
-	 * @since 1.0.0
-	 * @param int $product_id
-	 * @return bool
+	 * @inheritDoc
 	 */
-	protected function can_view( $product_id ) {
+	public function can_view( $product_id ) {
 		if ( ! \wc_memberships_is_product_viewing_restricted( $product_id ) ) {
 			return true;
 		}
@@ -72,13 +84,9 @@ class WooCommerce_Memberships extends \tad_DI52_ServiceProvider {
 	}
 
 	/**
-	 * Check if user can purchase a ticket.
-	 *
-	 * @since 1.0.0
-	 * @param int $product_id
-	 * @return bool
+	 * @inheritDoc
 	 */
-	protected function can_purchase( $product_id ) {
+	public function can_purchase( $product_id ) {
 		if ( ! \wc_memberships_is_product_purchasing_restricted( $product_id ) ) {
 			return true;
 		}

--- a/src/Tec/Plugin.php
+++ b/src/Tec/Plugin.php
@@ -2,12 +2,7 @@
 
 namespace Tribe\Extensions\Membersonlytickets;
 
-use Tribe\Extensions\Membersonlytickets\Integrations\Restrict_Content_Pro;
-use Tribe\Extensions\Membersonlytickets\Integrations\Paid_Memberships_Pro;
-use Tribe\Extensions\Membersonlytickets\Integrations\WooCommerce_Memberships;
-
 use Tribe\Extensions\Membersonlytickets\Integrations\Integration_Handler;
-
 
 /**
  * Class Plugin
@@ -98,16 +93,13 @@ class Plugin extends \tad_DI52_ServiceProvider {
 			return;
 		}
 
-
-		// $this->container->register( Restrict_Content_Pro::class );
-		// $this->container->register( WooCommerce_Memberships::class );
-		// $this->container->register( Paid_Memberships_Pro::class );
-
+		// Register the integrations.
 		$this->container->register( Integration_Handler::class );
 
 		// Do the settings.
 		$this->get_settings();
 
+		// Register core plugin hooks.
 		$this->container->register( Hooks::class );
 		// Todo: remove if we don't wind up loading any assets
 		// $this->container->register( Assets::class );

--- a/src/Tec/Plugin.php
+++ b/src/Tec/Plugin.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Tribe\Extensions\Membersonlytickets;
 
 use Tribe\Extensions\Membersonlytickets\Integrations\Restrict_Content_Pro;
@@ -94,23 +95,11 @@ class Plugin extends \tad_DI52_ServiceProvider {
 			return;
 		}
 
-		// Get active plugins
-		$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
 
 		// Restrict Content Pro
-		if ( in_array( 'restrict-content-pro/restrict-content-pro.php', $active_plugins ) ){
-			$this->container->register( Restrict_Content_Pro::class );
-		}
-
-		// WooCommerce Memberships
-		if ( in_array( 'woocommerce-memberships/woocommerce-memberships.php', $active_plugins ) ){
-			$this->container->register( WooCommerce_Memberships::class );
-		}
-
-		// Paid Memberships Pro
-		if ( in_array( 'paid-memberships-pro/paid-memberships-pro.php', $active_plugins ) ){
-			$this->container->register( Paid_Memberships_Pro::class );
-		}
+		$this->container->register( Restrict_Content_Pro::class );
+		$this->container->register( WooCommerce_Memberships::class );
+		$this->container->register( Paid_Memberships_Pro::class );
 
 		// Do the settings.
 		$this->get_settings();
@@ -129,6 +118,7 @@ class Plugin extends \tad_DI52_ServiceProvider {
 	 */
 	protected function check_plugin_dependencies() {
 		$this->register_plugin_dependencies();
+
 		return tribe_check_plugin( static::class );
 	}
 
@@ -175,19 +165,21 @@ class Plugin extends \tad_DI52_ServiceProvider {
 	 */
 	public function get_all_options() {
 		$settings = $this->get_settings();
+
 		return $settings->get_all_options();
 	}
 
 	/**
 	 * Get a specific extension option.
 	 *
-	 * @param $option
+	 * @param        $option
 	 * @param string $default
 	 *
 	 * @return array
 	 */
-	public function get_option( $option, $default ='' ) {
+	public function get_option( $option, $default = '' ) {
 		$settings = $this->get_settings();
+
 		return $settings->get_option( $option, $default );
 	}
 }

--- a/src/Tec/Plugin.php
+++ b/src/Tec/Plugin.php
@@ -6,6 +6,9 @@ use Tribe\Extensions\Membersonlytickets\Integrations\Restrict_Content_Pro;
 use Tribe\Extensions\Membersonlytickets\Integrations\Paid_Memberships_Pro;
 use Tribe\Extensions\Membersonlytickets\Integrations\WooCommerce_Memberships;
 
+use Tribe\Extensions\Membersonlytickets\Integrations\Integration_Handler;
+
+
 /**
  * Class Plugin
  *
@@ -96,10 +99,11 @@ class Plugin extends \tad_DI52_ServiceProvider {
 		}
 
 
-		// Restrict Content Pro
-		$this->container->register( Restrict_Content_Pro::class );
-		$this->container->register( WooCommerce_Memberships::class );
-		$this->container->register( Paid_Memberships_Pro::class );
+		// $this->container->register( Restrict_Content_Pro::class );
+		// $this->container->register( WooCommerce_Memberships::class );
+		// $this->container->register( Paid_Memberships_Pro::class );
+
+		$this->container->register( Integration_Handler::class );
 
 		// Do the settings.
 		$this->get_settings();


### PR DESCRIPTION
The work in this PR refactors the approach to registering and loading the integrations with various membership plugins. 

Previously, each integration was being registered directly from the main Plugin class. Instead, we have created a separate handler class that registers all the integrations with the container. 