### PR TITLE
Rename settings to be unique for each integration

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Event Tickets Extension: Members Only Tickets
  * Plugin URI:
  * GitHub Plugin URI: https://github.com/mt-support/tec-labs-members-only-tickets
- * Description:
+ * Description:       Hide or limit purchase of members only tickets.
  * Version:           1.0.0
  * Author:            The Events Calendar
  * Author URI:        https://evnt.is/1971

--- a/src/Tec/Integrations/MemberPress.php
+++ b/src/Tec/Integrations/MemberPress.php
@@ -56,14 +56,13 @@ class MemberPress extends \tad_DI52_ServiceProvider implements Integration_Inter
 		}
 
 		// Otherwise, check the settings to determine whether to show or not.
-		return ! tribe( 'extension.members_only_tickets.plugin' )->get_option( 'hide_member_tickets_memberpress' );
+		return ! tribe( 'extension.members_only_tickets.plugin' )->get_option( "{$this->get_id()}_hide_member_tickets" );
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	public function can_purchase( $product_id ) {
-
 		// If not a "members only" ticket, don't interfere.
 		if ( ! $this->is_member_ticket( $product_id ) ) {
 			return true;
@@ -98,7 +97,7 @@ class MemberPress extends \tad_DI52_ServiceProvider implements Integration_Inter
 	 */
 	public function settings( $settings ) {
 		$settings[ $this->get_id() ] = [
-			'members_settings_intro_memberpress' => [
+			"{$this->get_id()}_members_settings_intro" => [
 				'type' => 'html',
 				'html' => sprintf(
 					'<h3>%s</h3><p>%s</p>',
@@ -106,13 +105,13 @@ class MemberPress extends \tad_DI52_ServiceProvider implements Integration_Inter
 					esc_html__( 'Settings for MemberPress.', 'et-members-only-tickets' )
 				)
 			],
-			'hide_member_tickets_memberpress' => [
+			"{$this->get_id()}_hide_member_tickets" => [
 				'type'            => 'checkbox_bool',
 				'label'           => esc_html__( "Hide members only tickets.", 'et-members-only-tickets' ),
 				'tooltip'         => esc_html__( "When enabled, only members will see members only tickets.", 'et-members-only-tickets'),
 				'validation_type' => 'boolean',
 			],
-			'members_only_message' => [
+			"{$this->get_id()}_members_only_message" => [
 				'type'            => 'textarea',
 				'label'           => esc_html__( "Message for non-members.", 'et-members-only-tickets' ),
 				'tooltip'         => esc_html__( "Non-members will see this text as the ticket description.", 'et-members-only-tickets'),

--- a/src/Tec/Integrations/Paid_Memberships_Pro.php
+++ b/src/Tec/Integrations/Paid_Memberships_Pro.php
@@ -57,7 +57,7 @@ class Paid_Memberships_Pro extends \tad_DI52_ServiceProvider implements Integrat
 		}
 
 		// Otherwise, check the settings to determine whether to show or not.
-		return ! tribe( 'extension.members_only_tickets.plugin' )->get_option( 'hide_member_tickets' );
+		return ! tribe( 'extension.members_only_tickets.plugin' )->get_option( "{$this->get_id()}_hide_member_tickets" );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class Paid_Memberships_Pro extends \tad_DI52_ServiceProvider implements Integrat
 			return false;
 		}
 		// The required membership level.
-		$membership_level = tribe( 'extension.members_only_tickets.plugin' )->get_option( 'required_membership_level' );
+		$membership_level = tribe( 'extension.members_only_tickets.plugin' )->get_option( "{$this->get_id()}_required_membership_level" );
 
 		// Does the user have the required membership level?
 		return pmpro_hasMembershipLevel( $membership_level );
@@ -88,7 +88,7 @@ class Paid_Memberships_Pro extends \tad_DI52_ServiceProvider implements Integrat
 	 */
 	protected function is_member_ticket( $ticket_id ) {
 		// The category added to members only products in WooCommerce.
-		$members_only_product_category = tribe( 'extension.members_only_tickets.plugin' )->get_option( 'product_category' );
+		$members_only_product_category = tribe( 'extension.members_only_tickets.plugin' )->get_option( "{$this->get_id()}_product_category" );
 
 		// Is this a member ticket?
 		return has_term( $members_only_product_category, 'product_cat', $ticket_id );
@@ -103,7 +103,7 @@ class Paid_Memberships_Pro extends \tad_DI52_ServiceProvider implements Integrat
 	 */
 	public function settings( $settings ) {
 		$settings[ $this->get_id() ] = [
-			'members_settings_intro'   => [
+			"{$this->get_id()}_members_settings_intro"   => [
 				'type' => 'html',
 				'html' => sprintf(
 					'<h3>%s</h3><p>%s</p>',
@@ -111,25 +111,25 @@ class Paid_Memberships_Pro extends \tad_DI52_ServiceProvider implements Integrat
 					esc_html__( 'Settings for Paid Memberships Pro.', 'et-members-only-tickets' )
 				)
 			],
-			'product_category' => [
+			"{$this->get_id()}_product_category" => [
 				'type'            => 'text',
 				'label'           => esc_html__( "Product category", 'et-members-only-tickets' ),
 				'tooltip'         => esc_html__( "WooCommerce product category that designates a ticket to be members only.", 'et-members-only-tickets'),
 				'validation_type' => 'html',
 			],
-			'required_membership_level' => [
+			"{$this->get_id()}_required_membership_level" => [
 				'type'            => 'text',
 				'label'           => esc_html__( "Membership level", 'et-members-only-tickets' ),
 				'tooltip'         => esc_html__( "The membership level needed for a user to be able to purchase members only tickets.", 'et-members-only-tickets'),
 				'validation_type' => 'html',
 			],
-			'hide_member_tickets' => [
+			"{$this->get_id()}_hide_member_tickets" => [
 				'type'            => 'checkbox_bool',
 				'label'           => esc_html__( "Hide members only tickets.", 'et-members-only-tickets' ),
 				'tooltip'         => esc_html__( "When enabled, only members will see tickets with the members product category.", 'et-members-only-tickets'),
 				'validation_type' => 'boolean',
 			],
-			'members_only_message' => [
+			"{$this->get_id()}_members_only_message" => [
 				'type'            => 'textarea',
 				'label'           => esc_html__( "Message for non-members.", 'et-members-only-tickets' ),
 				'tooltip'         => esc_html__( "Non-members will see this text as the ticket description.", 'et-members-only-tickets'),

--- a/src/Tec/Integrations/Restrict_Content_Pro.php
+++ b/src/Tec/Integrations/Restrict_Content_Pro.php
@@ -70,7 +70,7 @@ class Restrict_Content_Pro extends \tad_DI52_ServiceProvider implements Integrat
 	 */
 	public function settings( $settings ) {
 		$settings[ $this->get_id() ] = [
-			'members_settings_intro' => [
+			"{$this->get_id()}_members_settings_intro" => [
 				'type' => 'html',
 				'html' => sprintf(
 					'<h3>%s</h3><p>%s</p>',
@@ -78,7 +78,7 @@ class Restrict_Content_Pro extends \tad_DI52_ServiceProvider implements Integrat
 					esc_html__( 'Settings for Restrict Content Pro.', 'et-members-only-tickets' )
 				)
 			],
-			'members_only_message' => [
+			"{$this->get_id()}_members_only_message" => [
 				'type'            => 'textarea',
 				'label'           => esc_html__( "Message for non-members.", 'et-members-only-tickets' ),
 				'tooltip'         => esc_html__( "Non-members will see this text as the ticket description.", 'et-members-only-tickets'),

--- a/src/Tec/Integrations/WooCommerce_Memberships.php
+++ b/src/Tec/Integrations/WooCommerce_Memberships.php
@@ -97,7 +97,7 @@ class WooCommerce_Memberships extends \tad_DI52_ServiceProvider implements Integ
 	 */
 	public function settings( $settings ) {
 		$settings[ $this->get_id() ] = [
-			'members_settings_intro' => [
+			"{$this->get_id()}_members_settings_intro" => [
 				'type' => 'html',
 				'html' => sprintf(
 					'<h3>%s</h3><p>%s</p>',
@@ -105,7 +105,7 @@ class WooCommerce_Memberships extends \tad_DI52_ServiceProvider implements Integ
 					esc_html__( 'Settings for WooCommerce Memberships.', 'et-members-only-tickets' )
 				)
 			],
-			'members_only_message' => [
+			"{$this->get_id()}_members_only_message" => [
 				'type'            => 'textarea',
 				'label'           => esc_html__( "Message for non-members.", 'et-members-only-tickets' ),
 				'tooltip'         => esc_html__( "Non-members will see this text as the ticket description.", 'et-members-only-tickets'),


### PR DESCRIPTION
The work in this PR renames the settings for each integration to be unique. This allows for the unlikely scenario that users have multiple membership plugins active. 