### PR TITLE
Fix bug when WC not active

### DIFF
--- a/src/TEC_Labs/Integrations/Integration_Abstract.php
+++ b/src/TEC_Labs/Integrations/Integration_Abstract.php
@@ -137,7 +137,7 @@ class Integration_Abstract {
 	 */
 	public function filter_cost( $costs, $post_id, $meta, $single ) {
 		// If not for the target meta, not single, or no costs, return early.
-		if ( '_EventCost' != $meta || $single || empty( $costs )  ) {
+		if ( '_EventCost' != $meta || $single || empty( $costs ) || ! class_exists( 'Woocommerce' )  ) {
 			return $costs;
 		}
 


### PR DESCRIPTION
Note: I don't think this is the best way of fixing the issue. I think it might cause the extension not to work when not using WooCommerce. I'm not sure, though.