### PR TITLE
Task/updates april 2023

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -4,7 +4,7 @@
  * Plugin URI:
  * GitHub Plugin URI: https://github.com/mt-support/tec-labs-members-only-tickets
  * Description:       Hide or limit purchase of members only tickets.
- * Version:           1.0.1
+ * Version:           1.0.2
  * Author:            The Events Calendar
  * Author URI:        https://evnt.is/1971
  * License:           GPL version 3 or any later version

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: theeventscalendar
 Donate link: https://evnt.is/29
 Tags: events, calendar
 Requires at least: 4.9
-Tested up to: 5.7
+Tested up to: 6.2
 Requires PHP: 5.6
-Stable tag: 1.0.0
+Stable tag: 1.0.2
 License: GPL version 3 or any later version
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -32,6 +32,12 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 We're always interested in your feedback and our [Help Desk](https://theeventscalendar.com/support) is the best place to flag an issue. However, note that we can only provide limited support for TEC Lab extensions.
 
 == Changelog ==
+
+= [1.0.2] 2023-04-30 =
+
+* Fix - MemberPress now shows members tickets when expected.
+* Fix - Added check for existence of WooCommerce before adding actions.
+* Enhancement - Added style wrapper around admin settings.
 
 = [1.0.1] 2022-05-19 =
 

--- a/src/TEC_Labs/Integrations/Integration_Abstract.php
+++ b/src/TEC_Labs/Integrations/Integration_Abstract.php
@@ -35,7 +35,7 @@ class Integration_Abstract {
 	 * @return void
 	 */
 	public function boot() {
-		if ( ! $this->is_active() ) {
+		if ( ! $this->is_active() || ! class_exists( 'Woocommerce' ) ) {
 			return;
 		}
 

--- a/src/TEC_Labs/Integrations/MemberPress.php
+++ b/src/TEC_Labs/Integrations/MemberPress.php
@@ -70,7 +70,10 @@ class MemberPress extends Integration_Abstract implements Integration_Interface 
 			return false;
 		}
 
-		return current_user_can( 'mepr-active', "product: {$product_id}" );
+		$product = get_post( $product_id );
+		$is_locked = \MeprRule::is_locked( $product );
+
+        return ! $is_locked;
 	}
 
 	/**

--- a/src/TEC_Labs/Integrations/MemberPress.php
+++ b/src/TEC_Labs/Integrations/MemberPress.php
@@ -95,6 +95,10 @@ class MemberPress extends Integration_Abstract implements Integration_Interface 
 	 */
 	public function settings( $settings ) {
 		$settings[ $this->get_id() ] = [
+            "{$this->get_id()}_members_settings_start" => [
+				'type' => 'html',
+				'html' => '<div class="tribe-settings-form-wrap">'
+			],
 			"{$this->get_id()}_members_settings_intro" => [
 				'type' => 'html',
 				'html' => sprintf(
@@ -107,7 +111,7 @@ class MemberPress extends Integration_Abstract implements Integration_Interface 
 				'type'            => 'checkbox_bool',
 				'label'           => esc_html__( "Hide members only tickets.", 'et-members-only-tickets' ),
 				'tooltip'         => esc_html__( "When enabled, only members will see members only tickets.", 'et-members-only-tickets'),
-				'validation_type' => 'boolean'
+				'validation_type' => 'boolean',
 			],
 			"{$this->get_id()}_members_only_message" => [
 				'type'            => 'textarea',
@@ -115,7 +119,11 @@ class MemberPress extends Integration_Abstract implements Integration_Interface 
 				'tooltip'         => esc_html__( "Non-members will see this text as the ticket description.", 'et-members-only-tickets'),
 				'default' 		  => esc_html__( "This ticket is for members only.", 'et-members-only-tickets' ),
 				'validation_type' => 'html'
-			]
+            ],
+            "{$this->get_id()}_members_settings_end" => [
+				'type' => 'html',
+				'html' => '</div>'
+			],            
 		];
 
 		return $settings;

--- a/src/TEC_Labs/Integrations/Paid_Memberships_Pro.php
+++ b/src/TEC_Labs/Integrations/Paid_Memberships_Pro.php
@@ -101,6 +101,10 @@ class Paid_Memberships_Pro extends Integration_Abstract implements Integration_I
 	 */
 	public function settings( $settings ) {
 		$settings[ $this->get_id() ] = [
+            "{$this->get_id()}_members_settings_start" => [
+				'type' => 'html',
+				'html' => '<div class="tribe-settings-form-wrap">'
+			],            
 			"{$this->get_id()}_members_settings_intro"   => [
 				'type' => 'html',
 				'html' => sprintf(
@@ -153,7 +157,11 @@ class Paid_Memberships_Pro extends Integration_Abstract implements Integration_I
 				'tooltip'         => esc_html__( 'Non-members will see this text in place of the ticket description.', 'et-members-only-tickets' ),
 				'default' 		  => esc_html__( 'This ticket is for members only.', 'et-members-only-tickets' ),
 				'validation_type' => 'html'
-			]
+            ],
+            "{$this->get_id()}_members_settings_end" => [
+				'type' => 'html',
+				'html' => '</div>'
+			],            
 		];
 
 		return $settings;

--- a/src/TEC_Labs/Integrations/Restrict_Content_Pro.php
+++ b/src/TEC_Labs/Integrations/Restrict_Content_Pro.php
@@ -67,6 +67,10 @@ class Restrict_Content_Pro extends Integration_Abstract implements Integration_I
 	 */
 	public function settings( $settings ) {
 		$settings[ $this->get_id() ] = [
+            "{$this->get_id()}_members_settings_start" => [
+				'type' => 'html',
+				'html' => '<div class="tribe-settings-form-wrap">'
+			],            
 			"{$this->get_id()}_members_settings_intro" => [
 				'type' => 'html',
 				'html' => sprintf(
@@ -81,7 +85,11 @@ class Restrict_Content_Pro extends Integration_Abstract implements Integration_I
 				'tooltip'         => esc_html__( 'Non-members will see this text as the ticket description.', 'et-members-only-tickets'),
 				'default' 		  => esc_html__( 'This ticket is for members only.', 'et-members-only-tickets' ),
 				'validation_type' => 'html'
-			]
+            ],
+            "{$this->get_id()}_members_settings_end" => [
+				'type' => 'html',
+				'html' => '</div>'
+			],            
 		];
 
 		return $settings;

--- a/src/TEC_Labs/Integrations/WooCommerce_Memberships.php
+++ b/src/TEC_Labs/Integrations/WooCommerce_Memberships.php
@@ -95,6 +95,10 @@ class WooCommerce_Memberships extends Integration_Abstract implements Integratio
 	 */
 	public function settings( $settings ) {
 		$settings[ $this->get_id() ] = [
+            "{$this->get_id()}_members_settings_start" => [
+				'type' => 'html',
+				'html' => '<div class="tribe-settings-form-wrap">'
+			],            
 			"{$this->get_id()}_members_settings_intro" => [
 				'type' => 'html',
 				'html' => sprintf(
@@ -109,7 +113,11 @@ class WooCommerce_Memberships extends Integration_Abstract implements Integratio
 				'tooltip'         => esc_html__( 'Non-members will see this text as the ticket description.', 'et-members-only-tickets'),
 				'default' 		  => esc_html__( 'This ticket is for members only.', 'et-members-only-tickets' ),
 				'validation_type' => 'html'
-			]
+            ],
+            "{$this->get_id()}_members_settings_end" => [
+				'type' => 'html',
+				'html' => '</div>'
+			],            
 		];
 
 		return $settings;


### PR DESCRIPTION
The work in this PR contains a few minor updates. 

1) Added a check for existence of main WooCommerce class before adding any actions, since all current integrations require WooCommerce as a payment provider. (Thanks Mike Cotton)

2) Added a wrapper to extension admin settings. Without the "tribe-settings-form-wrap" class on a containing element, the fields were not styled consistently with the rest of the Event Tickets admin settings.

3) Fix the can_purchase() method in MemberPress integration. The original way this was being checked only seemed like it was working, when logged in as admin. Found the correct utility method to use. 