### PR TITLE
Fix/tecext 342 wrong tickets hidden

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * Plugin Name:       Event Tickets Extension: Members Only Tickets
- * Plugin URI:
+ * Plugin URI:        https://theeventscalendar.com/extensions/members-only-tickets/
  * GitHub Plugin URI: https://github.com/mt-support/tec-labs-members-only-tickets
  * Description:       Hide or limit purchase of members only tickets.
- * Version:           1.0.3
+ * Version:           1.0.4
  * Author:            The Events Calendar
  * Author URI:        https://evnt.is/1971
  * License:           GPL version 3 or any later version

--- a/readme.txt
+++ b/readme.txt
@@ -2,10 +2,10 @@
 Contributors: theeventscalendar
 Donate link: https://evnt.is/29
 Tags: events, calendar
-Requires at least: 4.9
-Tested up to: 6.2
-Requires PHP: 5.6
-Stable tag: 1.0.3
+Requires at least: 6.3
+Tested up to: 6.7.1
+Requires PHP: 7.4
+Stable tag: 1.0.4
 License: GPL version 3 or any later version
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -32,6 +32,10 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 We're always interested in your feedback and our [Help Desk](https://theeventscalendar.com/support) is the best place to flag an issue. However, note that we can only provide limited support for TEC Lab extensions.
 
 == Changelog ==
+
+= [1.0.4] 2024-12-07 =
+
+* Fix - Make sure the correct tickets are hidden for restricted users.
 
 = [1.0.3] 2023-06-24 =
 

--- a/src/TEC_Labs/Integrations/Integration_Abstract.php
+++ b/src/TEC_Labs/Integrations/Integration_Abstract.php
@@ -63,7 +63,7 @@ class Integration_Abstract {
 	 * @param string $file
 	 * @param array  $name
 	 * @param object $obj
-	 *                   
+	 *
 	 * @return array
 	 */
 	public function remove_tickets_from_context( $context, $file, $name, $obj ) {

--- a/src/TEC_Labs/Integrations/Integration_Abstract.php
+++ b/src/TEC_Labs/Integrations/Integration_Abstract.php
@@ -57,10 +57,13 @@ class Integration_Abstract {
 	 * Maybe remove tickets from context.
 	 *
 	 * @since 1.0.0
+	 * @since 1.0.4 Re-index the tickets_on_sale array after removing an item.
+	 *
 	 * @param array  $context
 	 * @param string $file
 	 * @param array  $name
 	 * @param object $obj
+	 *                   
 	 * @return array
 	 */
 	public function remove_tickets_from_context( $context, $file, $name, $obj ) {
@@ -73,6 +76,9 @@ class Integration_Abstract {
 				$on_sale_index = array_search( $ticket->ID, array_column( $context['tickets_on_sale'], 'ID' ) );
 				unset( $context['tickets'][ $index ] );
 				unset( $context['tickets_on_sale'][ $on_sale_index ] );
+
+				// Re-index the tickets_on_sale array to make sure the old indices don't get mixed up with the new ones.
+				$context['tickets_on_sale'] = array_values( $context['tickets_on_sale'] );
 			}
 		}
 

--- a/src/TEC_Labs/Plugin.php
+++ b/src/TEC_Labs/Plugin.php
@@ -27,7 +27,7 @@ class Plugin extends Service_Provider {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.0.3';
+	const VERSION = '1.0.4';
 
 	/**
 	 * Stores the base slug for the plugin.


### PR DESCRIPTION
[TECEXT-342]

When having multiple tickets for an event with different visibility for members, then the wrong tickets might be shown.
This happens because before displaying the tickets we go through the ticket array, and remove the ones-to-be-hidden, from the array based on their index.
However, once we remove a ticket from the array, the indexes change, and if another ticket needs to be removed, the one with the wrong index might be removed.
In this fix, after the removal of a ticket we re-index the array to make sure that always the ticket with the correct index is being removed.

[TECEXT-342]: https://stellarwp.atlassian.net/browse/TECEXT-342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ